### PR TITLE
fix: run tests without relying on git

### DIFF
--- a/ABC/tests/bear-fuzzy-wuzzy/ABCtest.bats
+++ b/ABC/tests/bear-fuzzy-wuzzy/ABCtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd ABC
+  cd "$(find / -type d -path '*/languages/ABC' -print -quit 2>/dev/null)"
   plcc grammar
   javac -cp abcdatalog.jar Java/*.java
 }

--- a/ARRAY/tests/recursive/ARRAYtest.bats
+++ b/ARRAY/tests/recursive/ARRAYtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd ARRAY
+  cd "$(find / -type d -path '*/languages/ARRAY' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/BF/tests/random/BFtest.bats
+++ b/BF/tests/random/BFtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd BF
+  cd "$(find / -type d -path '*/languages/BF' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/CHAR/tests/random/CHARtest.bats
+++ b/CHAR/tests/random/CHARtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd CHAR
+  cd "$(find / -type d -path '*/languages/CHAR' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/GINGER/tests/ginger/GINGERtest.bats
+++ b/GINGER/tests/ginger/GINGERtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd GINGER
+  cd "$(find / -type d -path '*/languages/GINGER' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/HANDLER/tests/list/HANDLERtest.bats
+++ b/HANDLER/tests/list/HANDLERtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd HANDLER
+  cd "$(find / -type d -path '*/languages/HANDLER' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/INFIX/tests/add_and_multiply/INFIXtest.bats
+++ b/INFIX/tests/add_and_multiply/INFIXtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd INFIX
+  cd "$(find / -type d -path '*/languages/INFIX' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/LAMBDA/tests/random/LAMBDAtest.bats
+++ b/LAMBDA/tests/random/LAMBDAtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd LAMBDA
+  cd "$(find / -type d -path '*/languages/LAMBDA' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/LAMBDAQ/tests/free/LAMBDAQtest.bats
+++ b/LAMBDAQ/tests/free/LAMBDAQtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd LAMBDAQ
+  cd "$(find / -type d -path '*/languages/LAMBDAQ' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/LIST/tests/chooser/LISTtest.bats
+++ b/LIST/tests/chooser/LISTtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd LIST
+  cd "$(find / -type d -path '*/languages/LIST' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/LON/tests/parse/LONtest.bats
+++ b/LON/tests/parse/LONtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd LON
+  cd "$(find / -type d -path '*/languages/LON' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/LON2/tests/print/LON2test.bats
+++ b/LON2/tests/print/LON2test.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd LON2
+  cd "$(find / -type d -path '*/languages/LON2' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/LONN/tests/min/LONNtest.bats
+++ b/LONN/tests/min/LONNtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd LONN
+  cd "$(find / -type d -path '*/languages/LONN' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/NAME/tests/let-proc/NAMEtest.bats
+++ b/NAME/tests/let-proc/NAMEtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd NAME
+  cd "$(find / -type d -path '*/languages/NAME' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/NEED/tests/let/NEEDtest.bats
+++ b/NEED/tests/let/NEEDtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd NEED
+  cd "$(find / -type d -path '*/languages/NEED' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/OBJ/tests/class/OBJtest.bats
+++ b/OBJ/tests/class/OBJtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd OBJ
+  cd "$(find / -type d -path '*/languages/OBJ' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/PROP/tests/class-property/PROPtest.bats
+++ b/PROP/tests/class-property/PROPtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd PROP
+  cd "$(find / -type d -path '*/languages/PROP' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/RANDSCONT/tests/letrec/RANDSCONTtest.bats
+++ b/RANDSCONT/tests/letrec/RANDSCONTtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd RANDSCONT
+  cd "$(find / -type d -path '*/languages/RANDSCONT' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/REF/tests/let/REFtest.bats
+++ b/REF/tests/let/REFtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd REF
+  cd "$(find / -type d -path '*/languages/REF' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/REFCONT/tests/odd_even/REFCONTtest.bats
+++ b/REFCONT/tests/odd_even/REFCONTtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd REFCONT
+  cd "$(find / -type d -path '*/languages/REFCONT' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/SET/tests/let/SETtest.bats
+++ b/SET/tests/let/SETtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd SET
+  cd "$(find / -type d -path '*/languages/SET' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/THREADCONT/tests/concurrent/THREADCONTtest.bats
+++ b/THREADCONT/tests/concurrent/THREADCONTtest.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd THREADCONT
+  cd "$(find / -type d -path '*/languages/THREADCONT' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/TYPE0/tests/boolean/TYPE0test.bats
+++ b/TYPE0/tests/boolean/TYPE0test.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd TYPE0
+  cd "$(find / -type d -path '*/languages/TYPE0' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/TYPE1/tests/proc-types/TYPE1test.bats
+++ b/TYPE1/tests/proc-types/TYPE1test.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd TYPE1
+  cd "$(find / -type d -path '*/languages/TYPE1' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/V0/tests/nested-prims/V0test.bats
+++ b/V0/tests/nested-prims/V0test.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd V0
+  cd "$(find / -type d -path '*/languages/V0' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/V1/tests/nested-prims/V1test.bats
+++ b/V1/tests/nested-prims/V1test.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd V1
+  cd "$(find / -type d -path '*/languages/V1' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/V2/tests/nested-ifs/V2test.bats
+++ b/V2/tests/nested-ifs/V2test.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd V2
+  cd "$(find / -type d -path '*/languages/V2' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/V3/tests/let/V3test.bats
+++ b/V3/tests/let/V3test.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd V3
+  cd "$(find / -type d -path '*/languages/V3' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/V4/tests/proc/V4test.bats
+++ b/V4/tests/proc/V4test.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd V4
+  cd "$(find / -type d -path '*/languages/V4' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/V5/tests/letrec/V5test.bats
+++ b/V5/tests/letrec/V5test.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd V5
+  cd "$(find / -type d -path '*/languages/V5' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 

--- a/V6/tests/define/V6test.bats
+++ b/V6/tests/define/V6test.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(git rev-parse --show-toplevel)"
-  cd V6
+  cd "$(find / -type d -path '*/languages/V6' -print -quit 2>/dev/null)"
   plccmk -c grammar > /dev/null
 }
 


### PR DESCRIPTION
```
fix: run tests without relying on git

Tests can now be ran using bats no matter where you are located even if it is not a git repository

---

* Closes #14 

---
```