### PR TITLE
test: reduce dependencies

### DIFF
--- a/ABC/tests/bear-fuzzy-wuzzy/ABCtest.bats
+++ b/ABC/tests/bear-fuzzy-wuzzy/ABCtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/ABC' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plcc grammar
   javac -cp abcdatalog.jar Java/*.java
 }

--- a/ARRAY/tests/recursive/ARRAYtest.bats
+++ b/ARRAY/tests/recursive/ARRAYtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/ARRAY' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/BF/tests/random/BFtest.bats
+++ b/BF/tests/random/BFtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/BF' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -16,5 +17,5 @@ teardown() {
 
   expected_output=$(< "./tests/random/BF.expected")
   [[ "$RESULT" == "$expected_output" ]]
-  
+
 }

--- a/CHAR/tests/random/CHARtest.bats
+++ b/CHAR/tests/random/CHARtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/CHAR' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/GINGER/tests/ginger/GINGERtest.bats
+++ b/GINGER/tests/ginger/GINGERtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/GINGER' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/HANDLER/tests/list/HANDLERtest.bats
+++ b/HANDLER/tests/list/HANDLERtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/HANDLER' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/INFIX/tests/add_and_multiply/INFIXtest.bats
+++ b/INFIX/tests/add_and_multiply/INFIXtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/INFIX' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/LAMBDA/tests/random/LAMBDAtest.bats
+++ b/LAMBDA/tests/random/LAMBDAtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/LAMBDA' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/LAMBDAQ/tests/free/LAMBDAQtest.bats
+++ b/LAMBDAQ/tests/free/LAMBDAQtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/LAMBDAQ' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -11,7 +12,7 @@ teardown() {
 }
 
 @test "LAMBDAQ occurs_free" {
-  
+
   RESULT="$(rep -n < ./tests/free/LAMBDAQ.input)"
 
   expected_output=$(< "./tests/free/LAMBDAQ.expected")

--- a/LIST/tests/chooser/LISTtest.bats
+++ b/LIST/tests/chooser/LISTtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/LIST' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -11,7 +12,7 @@ teardown() {
 }
 
 @test "LIST chooser" {
-  
+
   RESULT="$(rep -n < ./tests/chooser/LIST.input)"
 
   expected_output=$(< "./tests/chooser/LIST.expected")

--- a/LON/tests/parse/LONtest.bats
+++ b/LON/tests/parse/LONtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/LON' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -11,7 +12,7 @@ teardown() {
 }
 
 @test "LON parse" {
-  
+
   RESULT="$(parse -n < ./tests/parse/LON.input)"
 
   [[ "$RESULT" =~ .*OK.* ]]

--- a/LON2/tests/print/LON2test.bats
+++ b/LON2/tests/print/LON2test.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/LON2' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -11,7 +12,7 @@ teardown() {
 }
 
 @test "LON2 print" {
-  
+
   RESULT="$(rep -n < ./tests/print/LON2.input)"
 
   expected_output=$(< "./tests/print/LON2.expected")

--- a/LONN/tests/min/LONNtest.bats
+++ b/LONN/tests/min/LONNtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/LONN' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -16,6 +17,6 @@ teardown() {
 
   expected_output=$(< "./tests/min/LONN.expected")
   [[ "$RESULT" == "$expected_output" ]]
-  
+
 }
 

--- a/NAME/tests/let-proc/NAMEtest.bats
+++ b/NAME/tests/let-proc/NAMEtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/NAME' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/NEED/tests/let/NEEDtest.bats
+++ b/NEED/tests/let/NEEDtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/NEED' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/OBJ/tests/class/OBJtest.bats
+++ b/OBJ/tests/class/OBJtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/OBJ' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/PROP/tests/class-property/PROPtest.bats
+++ b/PROP/tests/class-property/PROPtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/PROP' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/RANDSCONT/tests/letrec/RANDSCONTtest.bats
+++ b/RANDSCONT/tests/letrec/RANDSCONTtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/RANDSCONT' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -11,7 +12,7 @@ teardown() {
 }
 
 @test "RANDSCONT letrec" {
-  
+
   RESULT="$(rep -n < ./tests/letrec/RANDSCONT.input)"
 
   expected_output=$(< "./tests/letrec/RANDSCONT.expected")

--- a/REF/tests/let/REFtest.bats
+++ b/REF/tests/let/REFtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/REF' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/REFCONT/tests/odd_even/REFCONTtest.bats
+++ b/REFCONT/tests/odd_even/REFCONTtest.bats
@@ -1,18 +1,19 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/REFCONT' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
 teardown() {
   rm -rf "./Java"
   cd ..
-  
+
 }
 
 @test "REFCONT odd_even" {
-  
+
   RESULT="$(rep -n < ./tests/odd_even/REFCONT.input)"
 
   expected_output=$(< "./tests/odd_even/REFCONT.expected")

--- a/SET/tests/let/SETtest.bats
+++ b/SET/tests/let/SETtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/SET' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/THREADCONT/tests/concurrent/THREADCONTtest.bats
+++ b/THREADCONT/tests/concurrent/THREADCONTtest.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/THREADCONT' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -11,7 +12,7 @@ teardown() {
 }
 
 @test "THREADCONT concurrent" {
-  
+
   RESULT="$(rep -n < ./tests/concurrent/THREADCONT.input)"
 
   expected_output=$(< "./tests/concurrent/THREADCONT.expected")

--- a/TYPE0/tests/boolean/TYPE0test.bats
+++ b/TYPE0/tests/boolean/TYPE0test.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/TYPE0' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/TYPE1/tests/proc-types/TYPE1test.bats
+++ b/TYPE1/tests/proc-types/TYPE1test.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/TYPE1' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/V0/tests/nested-prims/V0test.bats
+++ b/V0/tests/nested-prims/V0test.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/V0' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/V1/tests/nested-prims/V1test.bats
+++ b/V1/tests/nested-prims/V1test.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/V1' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/V2/tests/nested-ifs/V2test.bats
+++ b/V2/tests/nested-ifs/V2test.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/V2' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -16,6 +17,6 @@ teardown() {
 
   expected_output=$(< "./tests/nested-ifs/V2.expected")
   [[ "$RESULT" == "$expected_output" ]]
-  
+
 }
 

--- a/V3/tests/let/V3test.bats
+++ b/V3/tests/let/V3test.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/V3' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -16,7 +17,7 @@ teardown() {
 
   expected_output=$(< "./tests/let/V3.expected")
   [[ "$RESULT" == "$expected_output" ]]
-  
+
 }
 
 

--- a/V4/tests/proc/V4test.bats
+++ b/V4/tests/proc/V4test.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/V4' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 
@@ -16,7 +17,7 @@ teardown() {
 
   expected_output=$(< "./tests/proc/V4.expected")
   [[ "$RESULT" == "$expected_output" ]]
-  
+
 }
 
 

--- a/V5/tests/letrec/V5test.bats
+++ b/V5/tests/letrec/V5test.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/V5' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/V6/tests/define/V6test.bats
+++ b/V6/tests/define/V6test.bats
@@ -1,7 +1,8 @@
 #!/usr/bin/env bats
 
 setup() {
-  cd "$(find / -type d -path '*/languages/V6' -print -quit 2>/dev/null)"
+  LANGUAGE_ROOT="${BATS_TEST_DIRNAME}/../.."
+  cd "${LANGUAGE_ROOT}"
   plccmk -c grammar > /dev/null
 }
 

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -2,6 +2,4 @@
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 PROJECT_ROOT="$( cd "${SCRIPT_DIR}/.." &> /dev/null && pwd )"
-cd "${PROJECT_ROOT}"
-
-bats --recursive .
+bats --recursive "${PROJECT_ROOT}"


### PR DESCRIPTION
```
test: reduce dependencies

Tests do not need to know the name of the directory
for the language they are testing, or the project
root, to find the files they need. Removing these
dependencies allows these files to be renamed without
breaking the test.
```

---

To test...

1. Open in GitPod
2. Run bin/test.bash