### PR TITLE
upgrade bats

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -5,6 +5,16 @@ tasks:
         /bin/bash -c "$(\curl -fsSL https://github.com/ourPLCC/plcc/raw/main/installers/plcc/install.bash)" \
           >> ~/.bashrc
         echo "INSTALLING bats (for testing: https://bats-core.readthedocs.io/en/latest/index.html)"
-        sudo apt-get update
-        sudo apt-get --no-install-recommends install bats
+        export BATS_VERSION=v1.11.0 \
+        && sudo apt-get update \
+        && sudo apt-get install -y \
+            git \
+        && sudo apt-get clean \
+        && sudo rm -rf /var/lib/apt/lists/* \
+        && sudo git clone https://github.com/bats-core/bats-core.git \
+        && cd bats-core \
+        && sudo git checkout $BATS_VERSION \
+        && sudo ./install.sh /usr/local \
+        && cd .. \
+        && sudo rm -rf bats-core
         exec bash


### PR DESCRIPTION
```
chore: upgrade bats version in gitpod

Gitpod will now use v1.11.0 of bats

---

* Closes #17 

---
```