### PR TITLE
refactor: use %include

### DIFF
--- a/src/ABC/grammar
+++ b/src/ABC/grammar
@@ -46,4 +46,4 @@ import abcdatalog.ast.*;
 %%%
 
 # semantics
-#include code
+%include code

--- a/src/ARRAY/grammar
+++ b/src/ARRAY/grammar
@@ -103,7 +103,7 @@ VAR '[A-Za-z\&\?\$][\w\?\&\$]*'
 # send obj msg(rands) is the same as .<obj>msg(rands)
 <exp>:SendExp    ::= SEND <exp>objExp <exp>procExp LPAREN <rands> RPAREN
 # with obj eval exp is the same as <obj>exp
-<exp>:WithExp    ::= WITH <exp>vExp EVAL <exp>eExp 
+<exp>:WithExp    ::= WITH <exp>vExp EVAL <exp>eExp
 <exp>:AtExp      ::= AT
 <exp>:AtAtExp    ::= ATAT
 <exp>:DisplayExp ::= DISPLAY <exp>
@@ -153,11 +153,11 @@ VAR '[A-Za-z\&\?\$][\w\?\&\$]*'
 <prim>:AddLstPrim   ::= ADDLSTOP
 <prim>:LenPrim      ::= LENOP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include list
-#include class
-#include ref
-#include len
+%include code
+%include prim
+%include envRef
+%include val
+%include list
+%include class
+%include ref
+%include len

--- a/src/HANDLER/grammar
+++ b/src/HANDLER/grammar
@@ -63,9 +63,9 @@ VAR '[A-Za-z][\w?]*'
 <prim>:Sub1Prim  ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include ref
-#include cont
+%include code
+%include prim
+%include envRef
+%include val
+%include ref
+%include cont

--- a/src/INFIX/grammar
+++ b/src/INFIX/grammar
@@ -45,7 +45,7 @@ VAR '[A-Za-z][\w?]*'
 <atom>:PrimappAtom     ::= <prim> LPAREN <rands> RPAREN
 <atom>:VarAtom         ::= <VAR> <assign>
 <atom>:ProcAtom        ::= PROC LPAREN <formals> RPAREN <block>
-<assign>:Assign0       ::= 
+<assign>:Assign0       ::=
 <assign>:Assign1       ::= EQUALS <atom>
 <fncalls>              **= LPAREN <rands> RPAREN
 <formals>              **= <VAR> +COMMA
@@ -63,8 +63,8 @@ VAR '[A-Za-z][\w?]*'
 <prim>:ZeropPrim       ::= ZEROP
 <prim>:PospPrim        ::= POSP
 %
-#include code
-#include envRef
-#include prim
-#include ref
-#include val
+%include code
+%include envRef
+%include prim
+%include ref
+%include val

--- a/src/LIST/grammar
+++ b/src/LIST/grammar
@@ -75,9 +75,9 @@ VAR '[A-Za-z][\w?]*'
 <prim>:LenPrim     ::= LENOP
 <prim>:ListpPrim   ::= LISTP
 %
-#include code
-#include prim
-#include envVal
-#include val
-#include listVal
-#include listPrim
+%include code
+%include prim
+%include envVal
+%include val
+%include listVal
+%include listPrim

--- a/src/NAME/grammar
+++ b/src/NAME/grammar
@@ -57,8 +57,8 @@ VAR '[A-Za-z][\w?]*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include ref
+%include code
+%include prim
+%include envRef
+%include val
+%include ref

--- a/src/NEED/grammar
+++ b/src/NEED/grammar
@@ -59,8 +59,8 @@ VAR '[A-Za-z][\w?]*'
 <prim>:ZeropPrim ::= ZEROP
 <prim>:ErrorPrim ::= ERROR
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include ref
+%include code
+%include prim
+%include envRef
+%include val
+%include ref

--- a/src/OBJ/grammar
+++ b/src/OBJ/grammar
@@ -153,11 +153,11 @@ VAR '[A-Za-z\&\?\$][\w\?\&\$]*'
 <prim>:ReversePrim   ::= REVERSEOP
 <prim>:AppendPrim    ::= APPENDOP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include listVal
-#include listPrim
-#include class
-#include ref
+%include code
+%include prim
+%include envRef
+%include val
+%include listVal
+%include listPrim
+%include class
+%include ref

--- a/src/PROP/grammar
+++ b/src/PROP/grammar
@@ -159,12 +159,12 @@ VAR '[A-Za-z\&\?\$][\w\?\&\$]*'
 <prim>:ReversePrim   ::= REVERSEOP
 <prim>:AppendPrim    ::= APPENDOP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include listVal
-#include listPrim
-#include class
-#include ref
-#include propRef
+%include code
+%include prim
+%include envRef
+%include val
+%include listVal
+%include listPrim
+%include class
+%include ref
+%include propRef

--- a/src/RANDSCONT/grammar
+++ b/src/RANDSCONT/grammar
@@ -58,9 +58,9 @@ VAR '[A-Za-z][\w?]*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include ref
-#include cont
+%include code
+%include prim
+%include envRef
+%include val
+%include ref
+%include cont

--- a/src/REF/grammar
+++ b/src/REF/grammar
@@ -57,8 +57,8 @@ VAR '[A-Za-z][\w?]*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include ref
+%include code
+%include prim
+%include envRef
+%include val
+%include ref

--- a/src/REFCONT/grammar
+++ b/src/REFCONT/grammar
@@ -57,9 +57,9 @@ VAR '[A-Za-z_][\w?]*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include ref
-#include cont
+%include code
+%include prim
+%include envRef
+%include val
+%include ref
+%include cont

--- a/src/SET/grammar
+++ b/src/SET/grammar
@@ -57,8 +57,8 @@ VAR '[A-Za-z][\w?]*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include ref
+%include code
+%include prim
+%include envRef
+%include val
+%include ref

--- a/src/THREADCONT/grammar
+++ b/src/THREADCONT/grammar
@@ -61,9 +61,9 @@ VAR '[A-Za-z_][\w?]*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include env
-#include val
-#include ref
-#include cont
+%include code
+%include prim
+%include env
+%include val
+%include ref
+%include cont

--- a/src/TYPE0/grammar
+++ b/src/TYPE0/grammar
@@ -84,8 +84,8 @@ VAR '[A-Za-z][\w?]*'
 <prim>:EQPrim   ::= EQP
 <prim>:NEPrim   ::= NEP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include ref
+%include code
+%include prim
+%include envRef
+%include val
+%include ref

--- a/src/TYPE1/grammar
+++ b/src/TYPE1/grammar
@@ -93,10 +93,10 @@ VAR '[A-Za-z][\w?]*'
 <prim>:OrPrim   ::= OROP
 <prim>:NotPrim  ::= NOTOP
 %
-#include code
-#include prim
-#include envRef
-#include val
-#include ref
-#include tenv
-#include type
+%include code
+%include prim
+%include envRef
+%include val
+%include ref
+%include tenv
+%include type

--- a/src/V0/grammar
+++ b/src/V0/grammar
@@ -23,4 +23,4 @@ VAR '[A-Za-z]\w*'
 <prim>:Add1Prim  ::= ADD1OP
 <prim>:Sub1Prim  ::= SUB1OP
 %
-#include code
+%include code

--- a/src/V1/grammar
+++ b/src/V1/grammar
@@ -32,7 +32,7 @@ VAR '[A-Za-z]\w*'
 <prim>:Sub1Prim  ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envRN
-#include val
+%include code
+%include prim
+%include envRN
+%include val

--- a/src/V2/grammar
+++ b/src/V2/grammar
@@ -35,7 +35,7 @@ VAR '[A-Za-z]\w*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envRN
-#include val
+%include code
+%include prim
+%include envRN
+%include val

--- a/src/V3/grammar
+++ b/src/V3/grammar
@@ -40,7 +40,7 @@ VAR '[A-Za-z]\w*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envVal
-#include val
+%include code
+%include prim
+%include envVal
+%include val

--- a/src/V4/grammar
+++ b/src/V4/grammar
@@ -51,7 +51,7 @@ VAR '[A-Za-z][\w?]*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envVal
-#include val
+%include code
+%include prim
+%include envVal
+%include val

--- a/src/V5/grammar
+++ b/src/V5/grammar
@@ -54,7 +54,7 @@ VAR '[A-Za-z][\w?]*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envVal
-#include val
+%include code
+%include prim
+%include envVal
+%include val

--- a/src/V6/grammar
+++ b/src/V6/grammar
@@ -56,7 +56,7 @@ VAR '[A-Za-z][\w?]*'
 <prim>:Sub1Prim ::= SUB1OP
 <prim>:ZeropPrim ::= ZEROP
 %
-#include code
-#include prim
-#include envVal
-#include val
+%include code
+%include prim
+%include envVal
+%include val


### PR DESCRIPTION
`#include` is deprecated under 6.2.0. Use `%include` instead.
